### PR TITLE
Fix skimage import error

### DIFF
--- a/net/utils.py
+++ b/net/utils.py
@@ -2,7 +2,7 @@ import math
 import torch
 import torch.nn as nn
 import numpy as np
-from skimage.measure.simple_metrics import compare_psnr
+from skimage.metrics import peak_signal_noise_ratio as compare_psnr
 from torchvision import models
 
 


### PR DESCRIPTION
Skimage changed their API and changed the function of psnr name
Changing `from skimage.measure.simple_metrics import compare_psnr` to `from skimage.metrics import peak_signal_noise_ratio as compare_psnr`
solved ` ModuleNotFoundError: No module named 'skimage.measure.simple_metrics'`